### PR TITLE
feat: add Panel Style setting (Translucent/Opaque)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+.DS_Store

--- a/EdgeMark/Core/Settings/AppSettings.swift
+++ b/EdgeMark/Core/Settings/AppSettings.swift
@@ -68,6 +68,24 @@ final class AppSettings {
         }
     }
 
+    // MARK: - Panel opacity
+
+    enum PanelStyle: String, CaseIterable {
+        case translucent
+        case opaque
+
+        var material: NSVisualEffectView.Material {
+            switch self {
+            case .translucent: .sidebar
+            case .opaque: .contentBackground
+            }
+        }
+    }
+
+    var panelStyle: PanelStyle = .translucent {
+        didSet { UserDefaults.standard.set(panelStyle.rawValue, forKey: "panelStyle") }
+    }
+
     // MARK: - Spell checking
 
     /// Mirrors `SpellCheckingPolicy.continuousSpellChecking`.
@@ -174,6 +192,11 @@ final class AppSettings {
         {
             panelTint = value
         }
+        if let raw = UserDefaults.standard.string(forKey: "panelStyle"),
+           let value = PanelStyle(rawValue: raw)
+        {
+            panelStyle = value
+        }
         // If the saved font is no longer installed (e.g. user uninstalled it),
         // drop it silently so the editor falls back to the system font.
         if let saved = UserDefaults.standard.string(forKey: "editorFontName"),
@@ -257,6 +280,15 @@ extension AppSettings.PanelTint {
         case .sand: l10n["settings.panelTint.sand"]
         case .sage: l10n["settings.panelTint.sage"]
         case .rose: l10n["settings.panelTint.rose"]
+        }
+    }
+}
+
+extension AppSettings.PanelStyle {
+    func displayName(_ l10n: L10n) -> String {
+        switch self {
+        case .translucent: l10n["settings.panelStyle.translucent"]
+        case .opaque: l10n["settings.panelStyle.opaque"]
         }
     }
 }

--- a/EdgeMark/Resources/Locales/en.json
+++ b/EdgeMark/Resources/Locales/en.json
@@ -155,6 +155,10 @@
   "settings.panelTint.sand": "Sand",
   "settings.panelTint.sage": "Sage",
   "settings.panelTint.rose": "Rose",
+  
+  "settings.general.panelStyle": "Panel Style",
+  "settings.panelStyle.translucent": "Translucent",
+  "settings.panelStyle.opaque": "Opaque",
 
   "settings.general.panelPosition": "Panel position",
   "settings.general.edge": "Edge",

--- a/EdgeMark/UI/Components/PageLayout.swift
+++ b/EdgeMark/UI/Components/PageLayout.swift
@@ -30,7 +30,7 @@ struct PageLayout<Header: View, Content: View>: View {
             header
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
-                .background { VisualEffectView(tint: appSettings.panelTint.color) }
+                .background { VisualEffectView(tint: appSettings.panelTint.color, material: appSettings.panelStyle.material) }
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .overlay {
                     if let onSwipeBack {
@@ -39,7 +39,7 @@ struct PageLayout<Header: View, Content: View>: View {
                 }
 
             content
-                .background { VisualEffectView(tint: appSettings.panelTint.color) }
+                .background { VisualEffectView(tint: appSettings.panelTint.color, material: appSettings.panelStyle.material) }
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .overlay {
                     if onContentSwipeRight != nil || onContentSwipeLeft != nil {

--- a/EdgeMark/UI/Components/Peek/PeekWindowController.swift
+++ b/EdgeMark/UI/Components/Peek/PeekWindowController.swift
@@ -257,7 +257,7 @@ private struct PeekChrome<Content: View>: View {
     var body: some View {
         content
             .background {
-                VisualEffectView(tint: tint)
+                VisualEffectView(tint: tint, material: AppSettings.shared.panelStyle.material)
             }
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .onExitCommand {

--- a/EdgeMark/UI/Components/VisualEffectView.swift
+++ b/EdgeMark/UI/Components/VisualEffectView.swift
@@ -7,10 +7,11 @@ import SwiftUI
 /// so foreground content (including code block syntax colors) is unaffected.
 struct VisualEffectView: NSViewRepresentable {
     var tint: NSColor?
+    var material: NSVisualEffectView.Material = .sidebar
 
     func makeNSView(context _: Context) -> TintableVisualEffectView {
         let view = TintableVisualEffectView()
-        view.material = .sidebar
+        view.material = material
         view.blendingMode = .behindWindow
         view.state = .active
         view.tintColor = tint
@@ -18,6 +19,7 @@ struct VisualEffectView: NSViewRepresentable {
     }
 
     func updateNSView(_ view: TintableVisualEffectView, context _: Context) {
+        view.material = material
         view.tintColor = tint
     }
 }

--- a/EdgeMark/UI/Settings/GeneralSettingsTab.swift
+++ b/EdgeMark/UI/Settings/GeneralSettingsTab.swift
@@ -47,6 +47,11 @@ struct GeneralSettingsTab: View {
                     ShortcutSettings.shared.appearanceMode = newValue
                 }
 
+                Picker(l10n["settings.general.panelStyle"], selection: $settings.panelStyle) {
+                    ForEach(AppSettings.PanelStyle.allCases, id: \.self) { style in
+                        Text(style.displayName(l10n)).tag(style)
+                    }
+                }
                 Picker(l10n["settings.general.panelTint"], selection: $settings.panelTint) {
                     ForEach(AppSettings.PanelTint.allCases, id: \.self) { tint in
                         Text(tint.displayName(l10n)).tag(tint)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ xattr -cr /Applications/EdgeMark.app
 - 📌 Pin to keep the panel open — survives focus changes, mouse exit, and Space switches (great for copy-pasting back and forth)
 - 📐 Multi-monitor support with configurable left or right edge
 - ↔️ Adjustable width — drag the inner edge to resize, saved across restarts
+- 🪟 Panel style — toggle between Translucent and Opaque panel backgrounds
 - 🎨 Panel tint — pick from a curated palette (System, Graphite, Slate, Sand, Sage, Rose)
 
 ✍️ **Markdown Editing**


### PR DESCRIPTION
In Settings adds an independent Translucent/Opaque toggle for the panel background material, addressing light-mode legibility because .sidebar material can render as a fairly saturated gray in light mode, even over white backgrounds even over white backgrounds, while .contentBackground gives a true light appearance. Default option remains Translucent.
README updated to document the new option alongside the existing Panel Tint entry.
Happy to adjust naming, defaults, or approach if you'd prefer something different.