### PR TITLE
Add Copy as Pathname to note/folder context menu

### DIFF
--- a/EdgeMark/Resources/Locales/de.json
+++ b/EdgeMark/Resources/Locales/de.json
@@ -40,6 +40,7 @@
   "common.copyPlainText": "Als Klartext kopieren",
   "common.copyMarkdown": "Als Markdown kopieren",
   "common.copyRTF": "Als Rich Text kopieren",
+  "common.copyAsPathname": "Als Pfadnamen kopieren",
   "common.deletePermanently": "Endgültig löschen",
   "common.folderNamePlaceholder": "Ordnername",
   "common.noteTitlePlaceholder": "Notiztitel",

--- a/EdgeMark/Resources/Locales/en.json
+++ b/EdgeMark/Resources/Locales/en.json
@@ -40,6 +40,7 @@
   "common.copyPlainText": "Copy as Plain Text",
   "common.copyMarkdown": "Copy as Markdown",
   "common.copyRTF": "Copy as Rich Text",
+  "common.copyAsPathname": "Copy as Pathname",
   "common.deletePermanently": "Delete Permanently",
   "common.folderNamePlaceholder": "Folder name",
   "common.noteTitlePlaceholder": "Note title",

--- a/EdgeMark/Resources/Locales/es.json
+++ b/EdgeMark/Resources/Locales/es.json
@@ -40,6 +40,7 @@
   "common.copyPlainText": "Copiar como texto plano",
   "common.copyMarkdown": "Copiar como Markdown",
   "common.copyRTF": "Copiar como texto enriquecido",
+  "common.copyAsPathname": "Copiar como ruta",
   "common.deletePermanently": "Eliminar permanentemente",
   "common.folderNamePlaceholder": "Nombre de la carpeta",
   "common.noteTitlePlaceholder": "Título de la nota",

--- a/EdgeMark/Resources/Locales/hi.json
+++ b/EdgeMark/Resources/Locales/hi.json
@@ -40,6 +40,7 @@
   "common.copyPlainText": "सादा टेक्स्ट के रूप में कॉपी करें",
   "common.copyMarkdown": "Markdown के रूप में कॉपी करें",
   "common.copyRTF": "रिच टेक्स्ट के रूप में कॉपी करें",
+  "common.copyAsPathname": "पाथनेम के रूप में कॉपी करें",
   "common.deletePermanently": "हमेशा के लिए हटाएं",
   "common.folderNamePlaceholder": "फ़ोल्डर का नाम",
   "common.noteTitlePlaceholder": "नोट का शीर्षक",

--- a/EdgeMark/Resources/Locales/zh-Hans.json
+++ b/EdgeMark/Resources/Locales/zh-Hans.json
@@ -40,6 +40,7 @@
   "common.copyPlainText": "复制为纯文本",
   "common.copyMarkdown": "复制为 Markdown",
   "common.copyRTF": "复制为富文本",
+  "common.copyAsPathname": "复制为路径名",
   "common.deletePermanently": "永久删除",
   "common.folderNamePlaceholder": "文件夹名称",
   "common.noteTitlePlaceholder": "笔记标题",

--- a/EdgeMark/UI/Components/NoteListMenus.swift
+++ b/EdgeMark/UI/Components/NoteListMenus.swift
@@ -206,6 +206,11 @@ enum NoteListMenus {
             ])
         }
 
+        menu.addActionItem(title: l10n["common.copyAsPathname"], icon: "doc.on.clipboard") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(FileStorage.urlForNote(note).path, forType: .string)
+        }
+
         menu.addItem(.separator())
 
         menu.addActionItem(title: l10n["common.delete"], icon: "trash") {
@@ -308,6 +313,11 @@ enum NoteListMenus {
             NSWorkspace.shared.activateFileViewerSelecting([
                 FileStorage.urlForFolder(folder.name),
             ])
+        }
+
+        menu.addActionItem(title: l10n["common.copyAsPathname"], icon: "doc.on.clipboard") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(FileStorage.urlForFolder(folder.name).path, forType: .string)
         }
 
         menu.addItem(.separator())


### PR DESCRIPTION
Closes #63

Adds a "Copy as Pathname" item to the note and folder context menus (next to "Show in Finder"). It copies the absolute file path (`FileStorage.urlForNote(note).path` for notes, `FileStorage.urlForFolder(folder.name).path` for folders) to the clipboard via `NSPasteboard.general.setString(_, forType: .string)`, reusing the same pattern as the existing copy items. No more detour through Finder to grab a path for pasting into other tools.

Changes:
- NoteListMenus.swift: new menu item in both noteMenu and folderMenu
- New localized key common.copyAsPathname in all 5 locales (en, de, es, hi, zh-Hans)

Checks: swiftformat --lint passes (0/73 files require formatting). Full Xcode build not exercised here (no complete Xcode available); CI build will cover it.